### PR TITLE
Make `npm run start` and `npm run export` work again

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -6,13 +6,16 @@ import * as sapper from "@sapper/server";
 const { PORT, NODE_ENV } = process.env;
 const dev = NODE_ENV === "development";
 
+const main = require.main === module || require.main.filename.match(/__sapper__\/build\/index.js$/);
+const local = dev || main;
+
 const expressServer = express().use(
 	compression({ threshold: 0 }),
 	sirv("static", { dev }),
 	sapper.middleware()
 );
 
-if (dev) {
+if (local) {
 	expressServer.listen(PORT, (err) => {
 		if (err) console.log("error", err);
 	});


### PR DESCRIPTION
This detects whether or not the `server.js` file is being called as the main file, like it is during `export`'s crawler, `dev`, `start`, but not when imported, to decide whether or not to run the server.

Maybe the `local` variable can just be reduced to `main` without `||`ing `dev`?
